### PR TITLE
Add play TuneIn Radio

### DIFF
--- a/sonos/sonos-queue.html
+++ b/sonos/sonos-queue.html
@@ -49,7 +49,8 @@
 			<option value="empty"></option>
 			<option value="directplay">Direct play</option>
             <option value="next">Queue next</option>
-            <option value="positioninqueue">Position in queue</option>				
+            <option value="positioninqueue">Position in queue</option>
+            <option value="tuneinradio">Play TuneIn Station</option>
         </select>
     </div>
 	

--- a/sonos/sonos-queue.js
+++ b/sonos/sonos-queue.js
@@ -48,6 +48,16 @@ module.exports = function(RED) {
 					}
 					node.log(JSON.stringify(result));
 				});
+			} else if (node.position === "tuneinradio" || payload.position === "tuneinradio") {
+				node.log("Play TuneIn Radio: " + _songuri);
+				node.client.playTuneinRadio(_songuri, function (err, result) {
+					msg.payload = result;
+					node.send(msg);
+					if (err) {
+						node.log(JSON.stringify(err));
+					}
+					node.log(JSON.stringify(result));
+				});
 			} else {				
 				// Default is queueing to the end of a queue
 				var set_position = 0;


### PR DESCRIPTION
If added the possibility to Play a TuneIn Radio directly via TuneIn Station Id (last part of the URL without the s), e.g.
https://tunein.com/radio/hr1-990-s7866/
will be stationId 7866